### PR TITLE
コンフィグに空の値がある場合に、空文字列を含むコマンドの生成を回避する

### DIFF
--- a/genomon_pipeline_cloud/batch_engine.py
+++ b/genomon_pipeline_cloud/batch_engine.py
@@ -46,7 +46,7 @@ class Dsub_factory(Abstract_factory):
 
     def generate_commands(self, task, general_param):
 
-        commands = ["dsub"] + general_param.split(' ') + task.resource_param.split(' ') + \
+        commands = ["dsub"] + general_param.split() + task.resource_param.split() + \
                      ["--logging", task.log_dir, "--script", task.script_file, \
                       "--image", task.image, "--tasks", task.task_file, "--wait"]
         return self.base_commands(commands)
@@ -72,7 +72,7 @@ class Azmon_factory(Abstract_factory):
 
     def generate_commands(self, task, general_param):
 
-        commands = ["azurebatchmon"] + general_param.split(' ') + task.resource_param.split(' ') + \
+        commands = ["azurebatchmon"] + general_param.split() + task.resource_param.split() + \
                      ["--script", task.script_file, "--image", task.image, "--tasks", task.task_file]
 
         return self.base_commands(commands)
@@ -98,7 +98,7 @@ class Awsub_factory(Abstract_factory):
 
     def generate_commands(self, task, general_param):
 
-        commands = ["awsub"] + general_param.split(' ') + task.resource_param.split(' ') + \
+        commands = ["awsub"] + general_param.split() + task.resource_param.split() + \
                      ["--script", task.script_file, "--image", task.image, "--tasks", task.task_file]
 
         return self.base_commands(commands)
@@ -126,7 +126,7 @@ class Ecsub_factory(Abstract_factory):
 
     def generate_commands(self, task, general_param):
 
-        commands = ["ecsub", "submit"] + general_param.split(' ') + task.resource_param.split(' ') + \
+        commands = ["ecsub", "submit"] + general_param.split() + task.resource_param.split() + \
                      ["--script", task.script_file, "--image", task.image, "--tasks", task.task_file] + \
                      ["--aws-s3-bucket", self.s3_wdir, "--wdir", self.wdir]
         


### PR DESCRIPTION
configの値が空の場合に、組み立てられるコマンドのオプションがずれて unrecognized arguments となる問題を修正します。

Pythonの`split`は[引数なしで呼び出すと空白文字で文字列を分割](https://docs.python.org/ja/3/library/stdtypes.html?highlight=split#str.split)しますが、元の文字列が空文字列の場合に空のリストを返します。
```python
>>> ''.split()
[]
>>> 'a b c'.split()
['a', 'b', 'c']
```

引数に空白文字を与えると、元の文字列が空文字列の場合に空文字列の入ったリストを返します。
```python
>>> ''.split(' ')
['']
>>> 'a b c'.split(' ')
['a', 'b', 'c']
```

この空文字列を使って`generate_commands`すると`subprocess.check_call`時に空の引数が増えるため、コマンド側からは意図しない入力となるようです。