### PR TITLE
ecsubを利用するDockerイメージを作る

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.idea
+build
+dist
+docker
+example_conf
+log
+test
+tmp
+.python-version
+.travis.yml
+LICENSE
+Dockerfile
+genomon_pipeline_cloud.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,23 @@
-FROM python:2.7.14
-MAINTAINER aokad <aokad@hgc.jp>
+FROM python:3.8.3-slim-buster AS builder
+WORKDIR /root
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends git=1:2.* && \
+  pip install awscli==1.18.79 boto3==1.14.2 pyyaml==5.3.1 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  git clone --depth=1 -b v0.0.18 https://github.com/aokad/ecsub.git && \
+  rm -rf /root/ecsub/.git
 
-RUN apt-get -y update && \
-    apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
-    apt-get -y install vim && \
-    \
-    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
-    apt-key fingerprint 0EBFCD88 && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
-    apt-get -y update && \
-    apt-get -y install docker-ce && \
-    apt-get -y install docker-ce=17.12.0~ce-0~debian && \
-    \
-    curl -L https://github.com/docker/machine/releases/download/v0.13.0/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && chmod +x /tmp/docker-machine && cp /tmp/docker-machine /usr/local/bin/docker-machine && \
-    \
-    mkdir /tools && \
-    cd /tools && \
-    wget https://github.com/otiai10/awsub/releases/download/v0.0.3/awsub.linux_amd64.tar.gz && \
-    tar -zxvf awsub.linux_amd64.tar.gz; rm awsub.linux_amd64.tar.gz && \
-    mv awsub /usr/local/bin/ && \
-    git clone https://github.com/otiai10/awsub.git && \
-    \
-    cd /tools && \
-    git clone https://github.com/Genomon-Project/genomon_pipeline_cloud.git && \
-    cd genomon_pipeline_cloud && \
-    pip install . --upgrade
-
-CMD ["bin/bash"]
-
-# for example
-# docker build -t gcloud .
-# docker run -it --name gcloud-a -e AWS_ACCESS_KEY_ID={your ID} -e AWS_SECRET_ACCESS_KEY={your KEY} gcloud
+FROM python:3.8.3-slim-buster AS genomon_pipeline_cloud
+LABEL maintainer="aokad <aokad@hgc.jp>"
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+COPY --from=builder /root/ecsub /root/ecsub
+WORKDIR /root/ecsub
+RUN python setup.py build install
+WORKDIR /root/genomon_pipeline_cloud
+COPY . /root/genomon_pipeline_cloud
+RUN python setup.py build install
+WORKDIR /root
+RUN rm -rf /root/ecsub /root/genomon_pipeline_cloud
+ENTRYPOINT ["genomon_pipeline_cloud", "--engine", "ecsub"]


### PR DESCRIPTION
`ecsub`を利用して`genomon_pipeline_cloud`を実行するDockerイメージを作ります。
entrypointに`genomon_pipeline_cloud`スクリプトを指定しているため、以下のようにコンフィグをマウントして実行ができます。

```shell
docker run \
  -v "${AWS_CONF_DIR}:/root/.aws:ro \
  -v "${CONF_DIR}":/root/example_conf:ro \
  "${DOCKER_IMAGE_ID}" \
  dna \
  /root/example_conf/sample_dna.csv \
  "${S3_BUCKET}" \
  /root/example_conf/param_dna_ecsub.cfg
```

#### 備考
- 再現性の向上のため、各ライブラリバージョンは固定しています。
- [マルチステージビルド](https://docs.docker.com/develop/develop-images/multistage-build/)構成で`ecsub`と依存ライブラリをダウンロードしてからコピーしています。
- 不要なファイルのコピーを避けるため[`.dockerignore`](https://docs.docker.com/engine/reference/builder/#dockerignore-file)を追加しています。
- `ecsub`はgitのtag`v0.0.18`をインストールしています。AWS credentialsの受け渡しに環境変数を利用する場合は aokad/ecsub#4 に依存しますので、`ecsub`でPullRequestをmergeして新しいtagをpushいただければ、後程あらためてecsubバージョン更新のPullRequestを`genomon_pipeline_cloud`に提出いたします。