### PR TITLE
sv-merge用に生成されるcontrol_info.txtの区切り文字の修正

### DIFF
--- a/genomon_pipeline_cloud/script/sv-merge.sh
+++ b/genomon_pipeline_cloud/script/sv-merge.sh
@@ -9,7 +9,7 @@ for i in `seq 1 $MAX_COUNT`; do
     TMP_INPUT_DIR=$(eval echo \$INPUT_DIR_${i})
     TMP_SAMPLE=$(eval echo \$SAMPLE_${i})
     if [ "$TMP_INPUT_DIR" != "" ]; then
-        echo "${TMP_SAMPLE}\t${TMP_INPUT_DIR}/${TMP_SAMPLE}" >> ${OUTPUT_DIR}/${PANEL_NAME}.control_info.txt
+        echo -e "${TMP_SAMPLE}\t${TMP_INPUT_DIR}/${TMP_SAMPLE}" >> ${OUTPUT_DIR}/${PANEL_NAME}.control_info.txt
     fi
 done
 


### PR DESCRIPTION
コントロールパネルを指定してDNAパイプラインを実行した際、 `sv-merge` の段階で以下のようなエラーが発生します：

```
Traceback (most recent call last):
File "/usr/local/bin/GenomonSV", line 11, in <module>
sys.exit(main())
File "/usr/local/lib/python2.7/dist-packages/genomon_sv/__init__.py", line 9, in main
args.func(args)
File "/usr/local/lib/python2.7/dist-packages/genomon_sv/run.py", line 241, in genomonSV_merge
label, output_prefix = line.rstrip('\n').split('\t')
ValueError: need more than 1 value to unpack 
```

`sv-merge` (`GenomonSV merge`) に対するコントロールパネルの設定はタブ区切りのフォーマットで `control_info.txt` ファイルにまとめられますが、`genomon_pipeline_cloud` で生成される `control_info.txt` では区切り文字としてタブ文字ではなく `\t` (バックスラッシュの後に小文字の `t`) が使われているため `GenomonSV` 側でコントロールパネルの設定をうまく読み込めていないようです。

この修正では、`control_info.txt` を生成する際に使われる `echo` コマンドに `-e` オプションを指定することでタブ区切りでファイルが生成されるようにしています。