### PR TITLE
Dockerイメージのecsubをv0.0.19にアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
   pip install awscli==1.18.91 boto3==1.14.14 pyyaml==5.3.1 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  git clone --depth=1 -b v0.0.18 https://github.com/aokad/ecsub.git && \
+  git clone --depth=1 -b v0.0.19 https://github.com/aokad/ecsub.git && \
   rm -rf /root/ecsub/.git
 
 FROM python:3.8.3-slim-buster AS genomon_pipeline_cloud

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8.3-slim-buster AS builder
 WORKDIR /root
 RUN apt-get update && \
   apt-get install -y --no-install-recommends git=1:2.* && \
-  pip install awscli==1.18.79 boto3==1.14.2 pyyaml==5.3.1 && \
+  pip install awscli==1.18.91 boto3==1.14.14 pyyaml==5.3.1 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   git clone --depth=1 -b v0.0.18 https://github.com/aokad/ecsub.git && \


### PR DESCRIPTION
https://github.com/aokad/ecsub/issues/6 のご対応をいただき、誠にありがとうございました。
本PRでは `genomon_pipeline_cloud` のdockerイメージで用いる `ecsub` のバージョンを `v0.0.19` にアップデートしています。
併せてPythonの依存ライブラリ[`awscli`](https://pypi.org/project/awscli/1.18.91/)及び[`boto3`](https://pypi.org/project/boto3/1.14.14/)もバージョンを更新しています。

また、蛇足ながら #11 も弊社から提出いたしましたPRでございます。ご多用中恐縮ですが、こちらもご高覧賜れますと幸甚に存じます。
