### PR TITLE
RNAパイプラインでGenomonSVを実行可能にする

### DIFF
--- a/example_conf/param_rna_ecsub.cfg
+++ b/example_conf/param_rna_ecsub.cfg
@@ -1,6 +1,33 @@
 [general]
 instance_option = --aws-log-group-name genomon
 
+[bwa_alignment]
+resource = --aws-ec2-instance-type t2.2xlarge --disk-size 80
+image = genomon/bwa_alignment:0.2.0
+bamtofastq_option = collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1
+bwa_option = -t 8 -T 0
+bwa_reference_dir = s3://genomon-bucket/_GRCh37/reference/GRCh37
+bwa_reference_file = GRCh37.fa
+bamsort_option = index=1 level=1 inputthreads=2 outputthreads=2 calmdnm=1 calmdnmrecompindentonly=1
+bammarkduplicates_option = markthreads=2 rewritebam=1 rewritebamlevel=1 index=1 md5=1
+
+[sv_parse]
+resource = --aws-ec2-instance-type t2.large --disk-size 15
+image = genomon/genomon_sv:0.1.0
+genomon_sv_parse_option =
+
+[sv_merge]
+resource = --aws-ec2-instance-type t2.large --disk-size 15
+image = genomon/genomon_sv:0.1.0
+genomon_sv_merge_option =
+
+[sv_filt]
+resource = --aws-ec2-instance-type t2.large --disk-size 50
+image = genomon/genomon_sv:0.1.0
+reference = s3://genomon-bucket/_GRCh37/reference/GRCh37/GRCh37.fa
+genomon_sv_filt_option =--grc --min_junc_num 2 --max_control_variant_read_pair 10 --min_overhang_size 30
+sv_utils_filt_option = --min_tumor_allele_freq 0.07 --max_control_variant_read_pair 1 --control_depth_thres 10 --inversion_size_thres 1000
+
 [star_alignment]
 resource = --aws-ec2-instance-type t2.2xlarge --disk-size 128
 image = genomon/star_alignment

--- a/example_conf/param_rna_ecsub_spot.cfg
+++ b/example_conf/param_rna_ecsub_spot.cfg
@@ -1,6 +1,33 @@
 [general]
 instance_option = --spot --aws-log-group-name genomon
 
+[bwa_alignment]
+resource = --aws-ec2-instance-type t2.2xlarge --disk-size 80
+image = genomon/bwa_alignment:0.2.0
+bamtofastq_option = collate=1 combs=1 exclude=QCFAIL,SECONDARY,SUPPLEMENTARY tryoq=1
+bwa_option = -t 8 -T 0
+bwa_reference_dir = s3://genomon-bucket/_GRCh37/reference/GRCh37
+bwa_reference_file = GRCh37.fa
+bamsort_option = index=1 level=1 inputthreads=2 outputthreads=2 calmdnm=1 calmdnmrecompindentonly=1
+bammarkduplicates_option = markthreads=2 rewritebam=1 rewritebamlevel=1 index=1 md5=1
+
+[sv_parse]
+resource = --aws-ec2-instance-type t2.large --disk-size 15
+image = genomon/genomon_sv:0.1.0
+genomon_sv_parse_option =
+
+[sv_merge]
+resource = --aws-ec2-instance-type t2.large --disk-size 15
+image = genomon/genomon_sv:0.1.0
+genomon_sv_merge_option =
+
+[sv_filt]
+resource = --aws-ec2-instance-type t2.large --disk-size 50
+image = genomon/genomon_sv:0.1.0
+reference = s3://genomon-bucket/_GRCh37/reference/GRCh37/GRCh37.fa
+genomon_sv_filt_option =--grc --min_junc_num 2 --max_control_variant_read_pair 10 --min_overhang_size 30
+sv_utils_filt_option = --min_tumor_allele_freq 0.07 --max_control_variant_read_pair 1 --control_depth_thres 10 --inversion_size_thres 1000
+
 [star_alignment]
 resource = --aws-ec2-instance-type-list t3.2xlarge,m4.2xlarge,t2.2xlarge --disk-size 128
 image = genomon/star_alignment

--- a/example_conf/sample_rna.csv
+++ b/example_conf/sample_rna.csv
@@ -1,6 +1,9 @@
 [fastq]
 MCF-7,s3://genomon-bucket/sample/rna/tumor/tumor.sequence1.fastq,s3://genomon-bucket/sample/rna/tumor/tumor.sequence2.fastq
 
+[sv_detection]
+MCF-7,None,None
+
 [fusion]
 MCF-7,None
 

--- a/genomon_pipeline_cloud/run.py
+++ b/genomon_pipeline_cloud/run.py
@@ -73,17 +73,37 @@ def run(args):
         import genomon_pipeline_cloud.tasks.genomon_expression as genomon_expression
         import genomon_pipeline_cloud.tasks.intron_retention as intron_retention
 
-        bwa_alignment_task = \
-            bwa_alignment.Bwa_alignment(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
-        sv_parse_task = \
-            sv_parse.SV_parse(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
-        sv_merge_task = \
-            sv_merge.SV_merge(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
-        sv_filt_task = \
-            sv_filt.SV_filt(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
-        p_sv = multiprocessing.Process(target=batch_engine.seq_execute,
-                                       args=([bwa_alignment_task, sv_parse_task, sv_merge_task, sv_filt_task],))
-        p_sv.start()
+        do_run_sv = sample_conf.sv_detection is not None and \
+                    len(sample_conf.sv_detection) > 0
+
+        if do_run_sv:
+            bwa_alignment_task = \
+                bwa_alignment.Bwa_alignment(args.output_dir,
+                                            tmp_dir,
+                                            sample_conf,
+                                            param_conf,
+                                            run_conf)
+            sv_parse_task = \
+                sv_parse.SV_parse(args.output_dir,
+                                  tmp_dir,
+                                  sample_conf,
+                                  param_conf,
+                                  run_conf)
+            sv_merge_task = \
+                sv_merge.SV_merge(args.output_dir,
+                                  tmp_dir,
+                                  sample_conf,
+                                  param_conf,
+                                  run_conf)
+            sv_filt_task = \
+                sv_filt.SV_filt(args.output_dir, tmp_dir, sample_conf,
+                                param_conf, run_conf)
+            p_sv = multiprocessing.Process(target=batch_engine.seq_execute,
+                                           args=([bwa_alignment_task,
+                                                  sv_parse_task,
+                                                  sv_merge_task,
+                                                  sv_filt_task],))
+            p_sv.start()
 
         star_alignment_task = star_alignment.Star_alignment(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
         fusion_count_task = fusion_count.Fusion_count(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
@@ -107,8 +127,9 @@ def run(args):
         p_fusion.join()
         p_expression.join()
         p_ir.join()
-        p_sv.join()
-        
+        if do_run_sv:
+            p_sv.join()
+
 
     ##########
     # DNA

--- a/genomon_pipeline_cloud/run.py
+++ b/genomon_pipeline_cloud/run.py
@@ -62,12 +62,28 @@ def run(args):
     # RNA
     if args.analysis_type == "rna":
 
+        import genomon_pipeline_cloud.tasks.bwa_alignment as bwa_alignment
+        import genomon_pipeline_cloud.tasks.sv_parse as sv_parse
+        import genomon_pipeline_cloud.tasks.sv_merge as sv_merge
+        import genomon_pipeline_cloud.tasks.sv_filt as sv_filt
         import genomon_pipeline_cloud.tasks.star_alignment as star_alignment
         import genomon_pipeline_cloud.tasks.fusion_count as fusion_count
         import genomon_pipeline_cloud.tasks.fusion_merge as fusion_merge
         import genomon_pipeline_cloud.tasks.fusionfusion as fusionfusion
         import genomon_pipeline_cloud.tasks.genomon_expression as genomon_expression
         import genomon_pipeline_cloud.tasks.intron_retention as intron_retention
+
+        bwa_alignment_task = \
+            bwa_alignment.Bwa_alignment(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
+        sv_parse_task = \
+            sv_parse.SV_parse(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
+        sv_merge_task = \
+            sv_merge.SV_merge(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
+        sv_filt_task = \
+            sv_filt.SV_filt(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
+        p_sv = multiprocessing.Process(target=batch_engine.seq_execute,
+                                       args=([bwa_alignment_task, sv_parse_task, sv_merge_task, sv_filt_task],))
+        p_sv.start()
 
         star_alignment_task = star_alignment.Star_alignment(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
         fusion_count_task = fusion_count.Fusion_count(args.output_dir, tmp_dir, sample_conf, param_conf, run_conf)
@@ -91,6 +107,7 @@ def run(args):
         p_fusion.join()
         p_expression.join()
         p_ir.join()
+        p_sv.join()
         
 
     ##########

--- a/genomon_pipeline_cloud/sample_conf.py
+++ b/genomon_pipeline_cloud/sample_conf.py
@@ -6,7 +6,8 @@ class Sample_conf(object):
 
     def __init__(self):
 
-        self.bam_file = {}
+        self.bwa_bam_file = {}
+        self.star_bam_file = {}
 
         self.fastq = {}
         self.bam_tofastq = {}
@@ -196,9 +197,10 @@ class Sample_conf(object):
                 """
                 self.fastq[sampleID] = [sequence1, sequence2]
                 if analysis_type == "rna":
-                    self.bam_file[sampleID] = output_dir+"/star/"+sampleID+"/"+sampleID+".Aligned.sortedByCoord.out.bam"
+                    self.star_bam_file[sampleID] = output_dir+"/star/"+sampleID+"/"+sampleID+".Aligned.sortedByCoord.out.bam"
+                    self.bwa_bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
                 elif analysis_type == "dna":
-                    self.bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
+                    self.bwa_bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
 
             elif mode == 'bam_tofastq':
 
@@ -229,9 +231,10 @@ class Sample_conf(object):
                 """
                 self.bam_tofastq[sampleID] = sequences
                 if analysis_type == "rna":
-                    self.bam_file[sampleID] = output_dir+"/star/"+sampleID+"/"+sampleID+".Aligned.sortedByCoord.out.bam"
+                    self.star_bam_file[sampleID] = output_dir+"/star/"+sampleID+"/"+sampleID+".Aligned.sortedByCoord.out.bam"
+                    self.bwa_bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
                 elif analysis_type == "dna":
-                    self.bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
+                    self.bwa_bam_file[sampleID] = output_dir+"/bam/"+sampleID+"/"+sampleID+".markdup.bam"
                 
             elif mode == 'bam_import':
 
@@ -247,8 +250,12 @@ class Sample_conf(object):
 
                 sampleID_list.append(sampleID)
 
-                if len(row) != 2:
-                    err_msg = sampleID + ": only one bam file is allowed"
+                if (analysis_type == 'dna' and len(row) == 2) or \
+                        (analysis_type == 'rna' and len(row) == 3):
+                    if analysis_type == 'dna':
+                        err_msg = sampleID + ": only one bam file is allowed"
+                    elif analysis_type == 'rna':
+                        err_msg = sampleID + ": STAR and BWA bam files are required"
                     raise ValueError(err_msg)
 
                 sequence = row[1]
@@ -266,7 +273,11 @@ class Sample_conf(object):
                 """
 
                 self.bam_import[sampleID] = sequence
-                self.bam_file[sampleID] = sequence
+                if analysis_type == "rna":
+                    self.bwa_bam_file[sampleID] = row[2]
+                    self.star_bam_file[sampleID] = sequence
+                elif analysis_type == "dna":
+                    self.bwa_bam_file[sampleID] = sequence
 
 
             elif mode == 'mutation_call':

--- a/genomon_pipeline_cloud/tasks/fusion_count.py
+++ b/genomon_pipeline_cloud/tasks/fusion_count.py
@@ -42,7 +42,7 @@ class Fusion_count(abstract_task.Abstract_task):
 
             for sample in control_sample_li_uniq:
 
-                bam = sample_conf.bam_file[sample]
+                bam = sample_conf.star_bam_file[sample]
                 bam_dir = os.path.dirname(bam)
 
                 hout.write('\t'.join([sample,

--- a/genomon_pipeline_cloud/tasks/fusionfusion.py
+++ b/genomon_pipeline_cloud/tasks/fusionfusion.py
@@ -37,7 +37,7 @@ class Fusionfusion(abstract_task.Abstract_task):
 
             for sample, panel_name  in sample_conf.fusion:
 
-                bam = sample_conf.bam_file[sample]
+                bam = sample_conf.star_bam_file[sample]
                 bam_dir = os.path.dirname(bam)
 
                 record = [sample,

--- a/genomon_pipeline_cloud/tasks/genomon_expression.py
+++ b/genomon_pipeline_cloud/tasks/genomon_expression.py
@@ -33,7 +33,7 @@ class Genomon_expression(abstract_task.Abstract_task):
                                   + "\n")
             for sample in sample_conf.expression:
 
-                bam = sample_conf.bam_file[sample]
+                bam = sample_conf.star_bam_file[sample]
                 bam_dir = os.path.dirname(bam)
                 bam_file = os.path.basename(bam)
 

--- a/genomon_pipeline_cloud/tasks/genomon_qc.py
+++ b/genomon_pipeline_cloud/tasks/genomon_qc.py
@@ -47,7 +47,7 @@ class Genomon_qc(abstract_task.Abstract_task):
 
             for sample in sample_conf.qc:
 
-                bam = sample_conf.bam_file[sample]
+                bam = sample_conf.bwa_bam_file[sample]
                 bam_dir = os.path.dirname(bam)
                 bam_file = os.path.basename(bam)
                 

--- a/genomon_pipeline_cloud/tasks/intron_retention.py
+++ b/genomon_pipeline_cloud/tasks/intron_retention.py
@@ -34,7 +34,7 @@ class Intron_retention(abstract_task.Abstract_task):
 
             for sample in sample_conf.intron_retention:
 
-                bam = sample_conf.bam_file[sample]
+                bam = sample_conf.star_bam_file[sample]
                 bam_dir = os.path.dirname(bam)
                 bam_file = os.path.basename(bam)
 

--- a/genomon_pipeline_cloud/tasks/mutation_call.py
+++ b/genomon_pipeline_cloud/tasks/mutation_call.py
@@ -59,14 +59,14 @@ class Mutation_call(abstract_task.Abstract_task):
                 sample_normal = sample[1] if sample[1] != None else "None"
                 control_panel = sample[2] if sample[2] != None else "None"
 
-                tumor_bam = sample_conf.bam_file[sample_tumor]
+                tumor_bam = sample_conf.bwa_bam_file[sample_tumor]
                 tumor_bam_dir = os.path.dirname(tumor_bam)
                 tumor_bam_file = os.path.basename(tumor_bam)
                 
                 normal_bam_dir = "" 
                 normal_bam_file = "" 
                 if sample_normal != "None": 
-                    normal_bam = sample_conf.bam_file[sample_normal]
+                    normal_bam = sample_conf.bwa_bam_file[sample_normal]
                     normal_bam_dir = os.path.dirname(normal_bam)
                     normal_bam_file = os.path.basename(normal_bam)
 

--- a/genomon_pipeline_cloud/tasks/paplot.py
+++ b/genomon_pipeline_cloud/tasks/paplot.py
@@ -65,7 +65,7 @@ class Paplot(abstract_task.Abstract_task):
         items = {"star": ["", ""], "fusion": ["", ""], "qc": ["", ""], "sv": ["", ""], "mutation": ["", ""], "signature": ["", ""], "pmsignature": ["", ""]}
         
         if run_conf.analysis_type == "rna":
-            items["star"]       = to_oneliner_starqc("starqc", sample_conf.qc, sample_conf.bam_file, ".Log.final.out")
+            items["star"]       = to_oneliner_starqc("starqc", sample_conf.qc, sample_conf.star_bam_file, ".Log.final.out")
             items["fusion"]     = to_oneliner("fusion", sample_conf.fusion, output_dir + "/fusion", ".genomonFusion.result.filt.txt")
         
         elif run_conf.analysis_type == "dna":

--- a/genomon_pipeline_cloud/tasks/sv_filt.py
+++ b/genomon_pipeline_cloud/tasks/sv_filt.py
@@ -42,14 +42,14 @@ class SV_filt(abstract_task.Abstract_task):
     
             for tumor_sample, normal_sample, control_panel_name in sample_conf.sv_detection:
 
-                tumor_bam = sample_conf.bam_file[tumor_sample]
+                tumor_bam = sample_conf.bwa_bam_file[tumor_sample]
                 tumor_bam_dir = os.path.dirname(tumor_bam)
                 tumor_bam_file = os.path.basename(tumor_bam)
 
                 normal_bam_dir = ""
                 normal_bam_file = ""
                 if normal_sample is not None:
-                    normal_bam = sample_conf.bam_file[normal_sample]
+                    normal_bam = sample_conf.bwa_bam_file[normal_sample]
                     normal_bam_dir = os.path.dirname(normal_bam)
                     normal_bam_file = os.path.basename(normal_bam)
 

--- a/genomon_pipeline_cloud/tasks/sv_parse.py
+++ b/genomon_pipeline_cloud/tasks/sv_parse.py
@@ -44,7 +44,7 @@ class SV_parse(abstract_task.Abstract_task):
             for sample_name in sorted(sample_list_for_parse):
                 if sample_name in list(sample_conf.bam_tofastq.keys()) + list(sample_conf.fastq.keys()) + list(sample_conf.bam_import.keys()):
 
-                    bam = sample_conf.bam_file[sample_name]
+                    bam = sample_conf.bwa_bam_file[sample_name]
                     bam_dir = os.path.dirname(bam)
                     bam_file = os.path.basename(bam)
 


### PR DESCRIPTION
##### 目的
`STIL`-`TAL1`や`IGH`に関する融合遺伝子の検出を目的として、RNAパイプラインで用いている`STAR`が当該融合遺伝子の配列をchimericにマップしないことから、RNAパイプラインで`bwa mem`及び`GenomonSV`を実行可能に修正します。

##### 修正
主な修正点は以下の通りです。
- `example_conf`のRNA用設定ファイル`cfg`に、DNA用から`GenomonSV`に関する設定をコピー
- `example_conf`のRNA用サンプル定義ファイル`csv`に、`[sv_detection]`の項目を追加
- ソースコード中の`bam_file`を`bwa_bam_file`と`star_bam_file`に分離
- RNAパイプライン中で`bwa_alignment`, `sv_parse`, `sv_merge`, `sv_filt`を、従来タスクとは独立して実行

これにより別途DNAパイプラインを実行しなくても`GenomonSV`の結果を得ることができます。
また今後DNAパイプラインとRNAパイプラインで独立に`GenomonSV`のバージョンやパラメタを設定可能です。
DNAパイプラインや、**サンプル定義ファイル`csv`中に`[sv_detection]`宣言がない場合のRNAパイプラインは、従来と変わらない**挙動を保ちます。

##### 結果
修正後のbranchで、サンプル定義ファイルに`[sv_detection]`の有るものと無いものそれぞれを実行し、結果ディレクトリを比較しました。
`bam/`以下に`bwa mem`のBAMファイルが、`sv/`以下に`GenomonSV`の出力が増えており、従来の`star/`等は変わりません。

```diff
@@ -1,3 +1,7 @@
+bam/MCF-7/MCF-7.markdup.bam
+bam/MCF-7/MCF-7.markdup.bam.bai
+bam/MCF-7/MCF-7.markdup.bam.md5
+bam/MCF-7/MCF-7.metrics
 expression/MCF-7/MCF-7.genomonExpression.result.txt
 expression/MCF-7/MCF-7.mapped_base_count.txt
 expression/MCF-7/MCF-7.ref2base.txt
@@ -53,3 +57,9 @@
 star/MCF-7/MCF-7.Log.out
 star/MCF-7/MCF-7.Log.progress.out
 star/MCF-7/MCF-7.SJ.out.tab
+sv/MCF-7/MCF-7.genomonSV.result.filt.txt
+sv/MCF-7/MCF-7.genomonSV.result.txt
+sv/MCF-7/MCF-7.improper.clustered.bedpe.gz
+sv/MCF-7/MCF-7.improper.clustered.bedpe.gz.tbi
+sv/MCF-7/MCF-7.junction.clustered.bedpe.gz
+sv/MCF-7/MCF-7.junction.clustered.bedpe.gz.tbi
```