### PR TITLE
fusionfusionの新フィルタに対応するためのアップデート

### DIFF
--- a/genomon_pipeline_cloud/script/fusionfusion.sh
+++ b/genomon_pipeline_cloud/script/fusionfusion.sh
@@ -3,13 +3,14 @@
 set -o errexit
 set -o xtrace
 
+INPUT_PREF=${INPUT_DIR}/${SAMPLE}
 OUTPUT_PREF=${OUTPUT_DIR}/${SAMPLE}
 mkdir -p ${OUTPUT_DIR}
 
 if [ "_${MERGED_COUNT_DIR}" != "_" ]; then
     OPTION="${OPTION} --pooled_control_file ${MERGED_COUNT_DIR}/${PANEL_NAME}.merged.Chimeric.count"
 fi
-/usr/local/bin/fusionfusion --star ${INPUT} --out ${OUTPUT_DIR} --reference_genome ${REFERENCE} ${OPTION}
+/usr/local/bin/fusionfusion --star ${INPUT_PREF} --out ${OUTPUT_DIR} --reference_genome ${REFERENCE} ${OPTION}
 
 mv ${OUTPUT_DIR}/star.fusion.result.txt ${OUTPUT_DIR}/${SAMPLE}.star.fusion.result.txt
 mv ${OUTPUT_DIR}/fusion_fusion.result.txt ${OUTPUT_DIR}/${SAMPLE}.genomonFusion.result.txt

--- a/genomon_pipeline_cloud/tasks/fusionfusion.py
+++ b/genomon_pipeline_cloud/tasks/fusionfusion.py
@@ -26,7 +26,7 @@ class Fusionfusion(abstract_task.Abstract_task):
         with open(task_file, 'w') as hout:
             
             hout.write('\t'.join(["--env SAMPLE",
-                                  "--input INPUT",
+                                  "--input-recursive INPUT_DIR",
                                   "--output-recursive OUTPUT_DIR",
                                   "--env OPTION",
                                   "--env FILT_OPTION",
@@ -41,7 +41,7 @@ class Fusionfusion(abstract_task.Abstract_task):
                 bam_dir = os.path.dirname(bam)
 
                 record = [sample,
-                          bam_dir +"/"+ sample + ".Chimeric.out.sam",
+                          bam_dir,
                           output_dir + "/fusion/" + sample,
                           param_conf.get("fusionfusion", "fusionfusion_option"),
                           param_conf.get("fusionfusion", "filt_option"),


### PR DESCRIPTION
「Genomon-Project/fusionfusion#12 近距離の融合遺伝子を検出するためのフィルタの実装」のプルリクエストに対応するためのアップデートです。

当該プルリクエストをマージすると、fusionfusionの`--star`オプションの意味が変更されるため、fusionfusionスクリプトへの入力ファイルの受け渡し方をそれに合わせて変更しています。